### PR TITLE
Fix goroutine wait bug

### DIFF
--- a/deputy-claimer/claim/bnb_claimer.go
+++ b/deputy-claimer/claim/bnb_claimer.go
@@ -100,7 +100,7 @@ func (bc BnbClaimer) fetchAndClaimSwaps() error {
 	}
 
 	// wait for all go routines to finish
-	for i := 0; i > len(bc.mnemonics); i++ {
+	for i := 0; i < len(bc.mnemonics); i++ {
 		<-availableMnemonics
 	}
 	// report any errors

--- a/deputy-claimer/claim/bnb_claimer.go
+++ b/deputy-claimer/claim/bnb_claimer.go
@@ -137,7 +137,7 @@ func getClaimableBnbSwaps(kavaClient kavaChainClient, bnbClient bnbChainClient, 
 		// get the random number for a claim transaction for the kava swap
 		randNum, err := kavaClient.getRandomNumberFromSwap(kID)
 		if err != nil {
-			log.Printf("could not fetch random num from kava swap ID %x: %w\n", kID, err)
+			log.Printf("could not fetch random num from kava swap ID %x: %v\n", kID, err)
 			continue
 		}
 		claimableSwaps = append(

--- a/deputy-claimer/claim/bnb_client.go
+++ b/deputy-claimer/claim/bnb_client.go
@@ -1,6 +1,8 @@
 package claim
 
 import (
+	"fmt"
+
 	bnbRpc "github.com/binance-chain/go-sdk/client/rpc"
 	"github.com/binance-chain/go-sdk/common/types"
 )
@@ -26,7 +28,7 @@ func (bc bnbChainClient) getOpenSwaps() ([]types.AtomicSwap, error) {
 	for {
 		swapIDsPage, err := bc.bnbSDKClient.GetSwapByRecipient(bc.deputyAddressString, queryOffset, querySwapsMaxPageSize)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to fetch swaps by recipient (offset %d): %w", queryOffset, err)
 		}
 		swapIDs = append(swapIDs, swapIDsPage...)
 		if len(swapIDsPage) < querySwapsMaxPageSize {
@@ -40,7 +42,7 @@ func (bc bnbChainClient) getOpenSwaps() ([]types.AtomicSwap, error) {
 	for _, id := range swapIDs {
 		s, err := bc.getSwapByID(id)
 		if err != nil {
-			return nil, err // TODO should probably retry on failure
+			return nil, fmt.Errorf("couldn't find swap for ID %x: %w", id, err) // TODO should probably retry on failure
 		}
 		if s.Status != types.Open {
 			continue

--- a/deputy-claimer/claim/kava_claimer.go
+++ b/deputy-claimer/claim/kava_claimer.go
@@ -103,7 +103,7 @@ func (kc KavaClaimer) fetchAndClaimSwaps() error {
 	}
 
 	// wait for all go routines to finish
-	for i := 0; i > len(kc.mnemonics); i++ {
+	for i := 0; i < len(kc.mnemonics); i++ {
 		<-availableMnemonics
 	}
 	// report any errors


### PR DESCRIPTION
When the deputy sent two or more txs at the same time it paniced. This was caused by a loop counter being checking incorrectly. Instead of waiting until all tx sending goroutines had finished, it continued on closing a channel which the still running goroutines tried to write to, causing the panic.