### PR TITLE
Add claimer config flag

### DIFF
--- a/claimer/config/config.go
+++ b/claimer/config/config.go
@@ -39,7 +39,7 @@ func NewConfig() *Config {
 	}
 }
 
-// GetConfig loads and validates the a configuration file, returning the Config struct if valid
+// GetConfig loads and validates a configuration file, returning the Config struct if valid
 func GetConfig(filePath string) (*Config, error) {
 	var config Config
 

--- a/claimer/config/config.go
+++ b/claimer/config/config.go
@@ -40,10 +40,10 @@ func NewConfig() *Config {
 }
 
 // GetConfig loads and validates the default configuration file, returning the Config struct if valid
-func GetConfig() (*Config, error) {
+func GetConfig(filePath string) (*Config, error) {
 	var config Config
 
-	err := loadConfig(DefaultConfigPath, &config)
+	err := loadConfig(filePath, &config)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func loadConfig(file string, config *Config) error {
 	}
 
 	fpClean := filepath.Clean(fp)
-	log.Info("Loading configuration", "path", fpClean)
+	log.Infof("Loading configuration path %s", fpClean)
 
 	f, err := os.Open(fpClean)
 	if err != nil {

--- a/claimer/config/config.go
+++ b/claimer/config/config.go
@@ -39,7 +39,7 @@ func NewConfig() *Config {
 	}
 }
 
-// GetConfig loads and validates the default configuration file, returning the Config struct if valid
+// GetConfig loads and validates the a configuration file, returning the Config struct if valid
 func GetConfig(filePath string) (*Config, error) {
 	var config Config
 

--- a/claimer/go.mod
+++ b/claimer/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/kava-labs/go-tools/deputy-claimer v0.0.0-20201223131958-31f436616e96
 	github.com/kava-labs/kava v0.12.1
 	github.com/sirupsen/logrus v1.4.2
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/tendermint/tendermint v0.33.9
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/claimer/main.go
+++ b/claimer/main.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	kava "github.com/kava-labs/kava/app"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 
 	"github.com/kava-labs/go-tools/claimer/claimer"
 	"github.com/kava-labs/go-tools/claimer/config"
@@ -13,12 +14,15 @@ import (
 )
 
 func main() {
+	configPath := pflag.String("config", config.DefaultConfigPath, "path to config file")
+	pflag.Parse()
+
 	// Load kava claimers
 	sdkConfig := sdk.GetConfig()
 	kava.SetBech32AddressPrefixes(sdkConfig)
 
 	// Load config
-	cfg, err := config.GetConfig()
+	cfg, err := config.GetConfig(*configPath)
 	if err != nil {
 		panic(err)
 	}

--- a/claimer/main.go
+++ b/claimer/main.go
@@ -33,10 +33,7 @@ func main() {
 
 	s := server.NewServer(dispatcher.JobQueue())
 	log.Info("Starting server...")
-	go func() {
-		if err := s.Start(); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
+	if err := s.Start(); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Adds a flag `--config` to specify non standard config file locations.

Also fixesa critical bug where the claimer wouldn't start. The main func would startup two go routines then immediately exit. Forgot to add a wait.