### PR TITLE
fix error type assertion

### DIFF
--- a/claimer/claimer/dispatcher.go
+++ b/claimer/claimer/dispatcher.go
@@ -101,17 +101,15 @@ func (d Dispatcher) Start(ctx context.Context) {
 
 				go func() {
 					defer sem.Release(1)
-					Retry(10, 20*time.Second, func() (err ClaimError) {
-						err = claimOnKava(d.config.Kava, http, claim, d.cdc, kavaClaimers)
-						return
+					Retry(10, 20*time.Second, func() error {
+						return claimOnKava(d.config.Kava, http, claim, d.cdc, kavaClaimers)
 					})
 				}()
 				break
 			case server.TargetBinance, server.TargetBinanceChain:
 				go func() {
-					Retry(10, 15*time.Second, func() (err ClaimError) {
-						err = claimOnBinanceChain(bnbClient, claim)
-						return
+					Retry(10, 15*time.Second, func() error {
+						return claimOnBinanceChain(bnbClient, claim)
 					})
 				}()
 				break

--- a/claimer/claimer/workers.go
+++ b/claimer/claimer/workers.go
@@ -26,7 +26,7 @@ import (
 // On kava-4, claim txs have historically reached up to 163072 gas.
 const ClaimTxDefaultGas = 200_000
 
-func claimOnBinanceChain(bnbHTTP brpc.Client, claim server.ClaimJob) ClaimError {
+func claimOnBinanceChain(bnbHTTP brpc.Client, claim server.ClaimJob) error {
 	swapID, err := hex.DecodeString(claim.SwapID)
 	if err != nil {
 		return NewErrorFailed(err)
@@ -68,7 +68,7 @@ func claimOnBinanceChain(bnbHTTP brpc.Client, claim server.ClaimJob) ClaimError 
 }
 
 func claimOnKava(config config.KavaConfig, http *rpcclient.HTTP, claim server.ClaimJob,
-	cdc *codec.Codec, kavaClaimers []KavaClaimer) ClaimError {
+	cdc *codec.Codec, kavaClaimers []KavaClaimer) error {
 	swapID, err := hex.DecodeString(claim.SwapID)
 	if err != nil {
 		return NewErrorFailed(err)
@@ -152,7 +152,7 @@ func claimOnKava(config config.KavaConfig, http *rpcclient.HTTP, claim server.Cl
 }
 
 // Check if swap is claimable
-func isClaimableKava(http *rpcclient.HTTP, cdc *codec.Codec, swapID []byte) ClaimError {
+func isClaimableKava(http *rpcclient.HTTP, cdc *codec.Codec, swapID []byte) error {
 	claimableParams := bep3.NewQueryAtomicSwapByID(swapID)
 	claimableBz, err := cdc.MarshalJSON(claimableParams)
 	if err != nil {
@@ -194,7 +194,7 @@ func isClaimableKava(http *rpcclient.HTTP, cdc *codec.Codec, swapID []byte) Clai
 	return nil
 }
 
-func getKavaAcc(http *rpcclient.HTTP, cdc *codec.Codec, fromAddr sdk.AccAddress) (uint64, uint64, ClaimError) {
+func getKavaAcc(http *rpcclient.HTTP, cdc *codec.Codec, fromAddr sdk.AccAddress) (uint64, uint64, error) {
 	params := authtypes.NewQueryAccountParams(fromAddr)
 	bz, err := cdc.MarshalJSON(params)
 	if err != nil {


### PR DESCRIPTION
This bug was missed in the #17 refactor. The error type assertion in the `Retry` func assumed the error was part of the `main` package, and was not updated when the errors were moved to the `claimer` package.

Changes
- updated the error type assertion to use go 1.13+ standard `errors.As(...`
- remove `ClaimError` in favour of the standard `error` interface