### PR TITLE
add docker build, tag, and push make integration for ECR repository

### DIFF
--- a/deputy-claimer/.dockerignore
+++ b/deputy-claimer/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+Makefile
+test

--- a/deputy-claimer/Dockerfile
+++ b/deputy-claimer/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.15.6-buster as build-env
+
+ADD . /src
+RUN cd /src && go build -o /main
+
+FROM debian:buster
+
+RUN apt-get update \
+      && apt-get install -y ca-certificates \
+      && rm -rf /var/lib/apt/lists/* \
+      && update-ca-certificates
+
+COPY --from=build-env /main /
+
+CMD ["/main"]

--- a/deputy-claimer/Makefile
+++ b/deputy-claimer/Makefile
@@ -1,3 +1,10 @@
+AWS:=aws
+AWS_REGION:=us-east-1
+DOCKER:=docker
+IMAGE_NAME:=deputy-claimer
+COMMIT_ID_SHORT:=$(shell git rev-parse --short HEAD)
+DOCKER_REPOSITORY_URL:=843137275421.dkr.ecr.us-east-1.amazonaws.com/$(IMAGE_NAME)
+
 install:
 	go install
 
@@ -13,3 +20,21 @@ test-integration:
 	@# run go vet first to avoid waiting for containers to spin up before finding there's a typo
 	go vet ./...
 	cd test/integration && run-tests.sh
+
+.PHONY: docker-login
+docker-login:
+	$(AWS) ecr get-login-password --region $(AWS_REGION) | \
+	docker login --username AWS --password-stdin \
+	$(shell aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.$(AWS_REGION).amazonaws.com
+
+.PHONY: docker-build
+docker-build:
+	$(DOCKER) build -t $(IMAGE_NAME):$(COMMIT_ID_SHORT) .
+
+.PHONY: docker-tag
+docker-tag:
+	$(DOCKER) tag $(IMAGE_NAME):$(COMMIT_ID_SHORT) $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)
+
+.PHONY: docker-push
+docker-push:
+	$(DOCKER) push $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)


### PR DESCRIPTION
Allows building, tagging, and pushing of deputy claim bot docker image for running on ECS Fargate