### PR TITLE
Fix Claimer Tx Commit Timeouts

### DIFF
--- a/claimer/claimer/client.go
+++ b/claimer/claimer/client.go
@@ -1,0 +1,117 @@
+package claimer
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/kava-labs/kava/x/bep3"
+	tmbytes "github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/libs/log"
+	rpcclient "github.com/tendermint/tendermint/rpc/client/http"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+type KavaClient struct {
+	http *rpcclient.HTTP
+	cdc  *codec.Codec
+}
+
+func NewKavaClient(cdc *codec.Codec, rpcAddr string, logger log.Logger) (*KavaClient, error) {
+	http, err := rpcclient.New(rpcAddr, "/websocket")
+	if err != nil {
+		return nil, err
+	}
+	http.Logger = logger
+
+	return &KavaClient{
+		cdc:  cdc,
+		http: http,
+	}, nil
+}
+
+func (c *KavaClient) GetChainID() (string, error) {
+	result, err := c.http.Status()
+	if err != nil {
+		return "", err
+	}
+	return result.NodeInfo.Network, nil
+}
+
+func (c *KavaClient) GetAccount(address sdk.AccAddress) (acc authexported.Account, err error) {
+	params := authtypes.NewQueryAccountParams(address)
+	bz, err := c.cdc.MarshalJSON(params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("custom/acc/account/%s", address.String())
+
+	result, err := c.ABCIQuery(path, bz)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.cdc.UnmarshalJSON(result, &acc)
+	if err != nil {
+		return nil, err
+	}
+
+	return acc, err
+}
+
+func (c *KavaClient) GetAtomicSwap(swapID []byte) (bep3.AtomicSwap, error) {
+	params := bep3.NewQueryAtomicSwapByID(swapID)
+	bz, err := c.cdc.MarshalJSON(params)
+	if err != nil {
+		return bep3.AtomicSwap{}, err
+	}
+
+	result, err := c.ABCIQuery("custom/bep3/swap", bz)
+	if err != nil {
+		return bep3.AtomicSwap{}, err
+	}
+
+	var swap bep3.AtomicSwap
+	err = c.cdc.UnmarshalJSON(result, &swap)
+	if err != nil {
+		return bep3.AtomicSwap{}, err
+	}
+	return swap, nil
+}
+
+func (c *KavaClient) ABCIQuery(path string, data tmbytes.HexBytes) ([]byte, error) {
+	result, err := c.http.ABCIQuery(path, data)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	resp := result.Response
+	if !resp.IsOK() {
+		return []byte{}, errors.New(resp.Log)
+	}
+
+	value := result.Response.GetValue()
+	if len(value) == 0 {
+		return []byte{}, nil // TODO error?
+	}
+
+	return value, nil
+}
+
+func (c *KavaClient) BroadcastTxSync(tx tmtypes.Tx) (*ctypes.ResultBroadcastTx, error) {
+	return c.http.BroadcastTxSync(tx)
+}
+
+func (c *KavaClient) BroadcastTxCommit(tx tmtypes.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+	return c.http.BroadcastTxCommit(tx)
+}
+
+func (c *KavaClient) GetTxConfirmation(txHash []byte) (*ctypes.ResultTx, error) {
+	return c.http.Tx(txHash, false)
+}

--- a/claimer/claimer/client.go
+++ b/claimer/claimer/client.go
@@ -98,7 +98,7 @@ func (c *KavaClient) ABCIQuery(path string, data tmbytes.HexBytes) ([]byte, erro
 
 	value := result.Response.GetValue()
 	if len(value) == 0 {
-		return []byte{}, nil // TODO error?
+		return []byte{}, nil
 	}
 
 	return value, nil

--- a/claimer/claimer/workers.go
+++ b/claimer/claimer/workers.go
@@ -4,10 +4,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net/url"
 	"strings"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -85,7 +83,7 @@ func claimOnBinanceChain(bnbHTTP brpc.Client, claim server.ClaimJob) error {
 // 	}
 // }
 
-func claimOnKava(config config.KavaConfig, client *KavaClient, claim server.ClaimJob, kavaClaimers []KavaClaimer) error {
+func claimOnKava(config config.KavaConfig, client *KavaClient, claim server.ClaimJob, claimer KavaClaimer) error {
 	swapID, err := hex.DecodeString(claim.SwapID)
 	if err != nil {
 		return NewErrorFailed(err)
@@ -95,24 +93,6 @@ func claimOnKava(config config.KavaConfig, client *KavaClient, claim server.Clai
 	if err != nil {
 		return err
 	}
-
-	var claimer KavaClaimer
-	var randNum int
-	selectedClaimer := false
-	for !selectedClaimer {
-		source := rand.NewSource(time.Now().UnixNano())
-		r := rand.New(source)
-		randNum = r.Intn(len(kavaClaimers))
-		randClaimer := kavaClaimers[randNum]
-		if randClaimer.Status {
-			selectedClaimer = true
-			kavaClaimers[randNum].Status = false
-			claimer = randClaimer
-		}
-	}
-	defer func() {
-		kavaClaimers[randNum].Status = true
-	}()
 
 	fromAddr := claimer.Keybase.GetAddr()
 

--- a/claimer/claimer/workers_test.go
+++ b/claimer/claimer/workers_test.go
@@ -1,0 +1,31 @@
+package claimer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPollWithBackoff(t *testing.T) {
+
+	pollTimes := []time.Duration{}
+	start := time.Now()
+
+	err := pollWithBackoff(time.Second, 100*time.Millisecond, func() (bool, error) {
+		pollTimes = append(pollTimes, time.Since(start))
+		return false, nil
+	})
+	require.Error(t, err)
+
+	expectedPollTimes := []time.Duration{
+		0 * time.Millisecond,
+		100 * time.Millisecond,
+		300 * time.Millisecond,
+		700 * time.Millisecond,
+	}
+
+	// check actual times are within some percent of expected
+	// drop first 0 time as the error is variable
+	require.InEpsilonSlice(t, expectedPollTimes[1:], pollTimes[1:], 0.05)
+}

--- a/claimer/main.go
+++ b/claimer/main.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	kava "github.com/kava-labs/kava/app"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
@@ -26,6 +27,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	log.SetLevel(logrus.DebugLevel)
 
 	dispatcher := claimer.NewDispatcher(*cfg)
 	ctx := context.Background()

--- a/deputy-claimer/test/swap/clients.go
+++ b/deputy-claimer/test/swap/clients.go
@@ -66,10 +66,10 @@ func (swapClient KavaSwapClient) broadcastMsg(msg sdk.Msg, signerMnemonic string
 
 	res, err := kavaClient.Broadcast(msg, mode)
 	if err != nil {
-		return res.Hash, fmt.Errorf("swap rejected from node: %w", err)
+		return nil, err
 	}
 	if res.Code != 0 {
-		return res.Hash, fmt.Errorf("tx rejected from chain: %s", res.Log)
+		return res.Hash, fmt.Errorf("tx rejected: %s", res.Log)
 	}
 	return res.Hash, nil
 }


### PR DESCRIPTION
This PR aims to fix an issue where kava txs were being brodcast with `Commit` but the kava node was timing out waiting for the tx to be submitted.

There were two errors seen:
- `retrying: broadcast_tx_commit: RPC error -32603 - Internal error: timed out waiting for tx to be included in a block`
- `failed: broadcast_tx_commit: Post failed: Post http://kava4.data.kava.io:26657: EOF`

This first corresonds to a timeout, the second seemed related but I wasn't able to get determine it's cause.
Instead this PR changes the claimer to broadcast txs with `Sync` and poll the node for confirmation. This allows more control over timeouts, and should avoid the above issues.

Other Changes
- add tx fees for kava txs (@0.25ukava / gas) to speed up confirmations
- refactor out kava quering into a `KavaClient`
- simplify the kava mnemonic selection using channels instead of the `KavaClaimer` struct