### PR TITLE
Increase deputy claimer tx timeout

### DIFF
--- a/deputy-claimer/claim/addresses.go
+++ b/deputy-claimer/claim/addresses.go
@@ -7,13 +7,17 @@ import (
 	"github.com/kava-labs/binance-chain-go-sdk/common/types"
 )
 
+// DeputyAddress contains the kava and bnb addresses for a single deputy process.
 type DeputyAddress struct {
 	Kava sdk.AccAddress
 	Bnb  types.AccAddress
 }
 
+// DeputyAddresses holds all on-chain addresses for multiple deputy processes.
+// It provides convenience lookup methods to fetch addresses.
 type DeputyAddresses map[string]DeputyAddress
 
+// AllKava return the kava addresses for all deputies
 func (deputyAddresses DeputyAddresses) AllKava() []sdk.AccAddress {
 	var addresses []sdk.AccAddress
 	for _, da := range deputyAddresses {
@@ -22,6 +26,7 @@ func (deputyAddresses DeputyAddresses) AllKava() []sdk.AccAddress {
 	return addresses
 }
 
+// AllBnb return the bnb chain addresses for all deputies
 func (deputyAddresses DeputyAddresses) AllBnb() []types.AccAddress {
 	var addresses []types.AccAddress
 	for _, da := range deputyAddresses {
@@ -30,6 +35,7 @@ func (deputyAddresses DeputyAddresses) AllBnb() []types.AccAddress {
 	return addresses
 }
 
+// GetMatchingBnb finds the bnb chain address for the deputy with the provided kava address
 func (deputyAddresses DeputyAddresses) GetMatchingBnb(kavaAddress sdk.AccAddress) (types.AccAddress, bool) {
 	for _, da := range deputyAddresses {
 		if da.Kava.Equals(kavaAddress) {
@@ -39,6 +45,7 @@ func (deputyAddresses DeputyAddresses) GetMatchingBnb(kavaAddress sdk.AccAddress
 	return nil, false
 }
 
+// GetMatchingKava finds the kava address for the deputy with the provided bnb chain address
 func (deputyAddresses DeputyAddresses) GetMatchingKava(bnbAddress types.AccAddress) (sdk.AccAddress, bool) {
 	for _, da := range deputyAddresses {
 		if bytes.Equal(da.Bnb.Bytes(), bnbAddress.Bytes()) {

--- a/deputy-claimer/claim/bnb_claimer.go
+++ b/deputy-claimer/claim/bnb_claimer.go
@@ -53,7 +53,7 @@ func NewBnbClaimer(kavaRestURL, kavaRPCURL, bnbRPCURL string, depAddrs DeputyAdd
 		deputyAddresses: depAddrs,
 	}
 }
-func (bc BnbClaimer) Run(ctx context.Context) {
+func (bc BnbClaimer) Start(ctx context.Context) {
 	go func(ctx context.Context) {
 		nextPoll := time.After(0) // set wait to zero so it fires on startup
 		for {
@@ -134,7 +134,7 @@ func (bc BnbClaimer) fetchAndClaimSwaps() error {
 }
 
 type bnbClaimableSwap struct {
-	swapID       tmbytes.HexBytes // XXX should define my own byte type to abstract the different ones each chain uses
+	swapID       tmbytes.HexBytes
 	destSwapID   tmbytes.HexBytes
 	randomNumber tmbytes.HexBytes
 	amount       types.Coins

--- a/deputy-claimer/claim/bnb_claimer.go
+++ b/deputy-claimer/claim/bnb_claimer.go
@@ -16,6 +16,11 @@ import (
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 )
 
+const (
+	bnbTxTimeout    time.Duration = 1 * time.Minute
+	bnbLoopInterval time.Duration = 5 * time.Minute
+)
+
 type BnbClaimError struct {
 	Swap bnbClaimableSwap
 	Err  error
@@ -50,19 +55,19 @@ func NewBnbClaimer(kavaRestURL, kavaRPCURL, bnbRPCURL string, depAddrs DeputyAdd
 }
 func (bc BnbClaimer) Run(ctx context.Context) {
 	go func(ctx context.Context) {
+		nextPoll := time.After(0) // set wait to zero so it fires on startup
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
+			case <-nextPoll:
 				log.Println("finding available deputy claims for bnb")
 				err := bc.fetchAndClaimSwaps()
 				if err != nil {
 					log.Printf("error fetching and claiming bnb swaps: %v\n", err)
 				}
-				time.Sleep(5 * time.Minute)
-				continue
 			}
+			nextPoll = time.After(bnbLoopInterval)
 		}
 	}(ctx)
 }
@@ -94,7 +99,7 @@ func (bc BnbClaimer) fetchAndClaimSwaps() error {
 				errs <- BnbClaimError{Swap: swap, Err: fmt.Errorf("could not submit claim: %w", err)}
 				return
 			}
-			err = Wait(15*time.Second, func() (bool, error) {
+			err = Wait(bnbTxTimeout, func() (bool, error) {
 				res, err := bc.bnbClient.GetTxConfirmation(txHash)
 				if err != nil {
 					return false, nil

--- a/deputy-claimer/main.go
+++ b/deputy-claimer/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	// Set global address prefixes
 	kavaConfig := sdk.GetConfig()
-	app.SetBech32AddressPrefixes(kavaConfig) // XXX G34 descend only one level of abstraction
+	app.SetBech32AddressPrefixes(kavaConfig)
 	kavaConfig.Seal()
 
 	cfg, err := loadConfig()
@@ -77,16 +77,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// XXX G30 functions should do one thing
-
-	// XXX F1 too many arguments
-	// XXX G5 duplication
 	kavaClaimer := claim.NewKavaClaimer(cfg.KavaRestURL, cfg.KavaRPCURL, cfg.BnbRPCURL, cfg.Deputies, cfg.KavaMnemonics)
 	bnbClaimer := claim.NewBnbClaimer(cfg.KavaRestURL, cfg.KavaRPCURL, cfg.BnbRPCURL, cfg.Deputies, cfg.BnbMnemonics)
 
-	ctx := context.Background() // XXX G34 too many levels of abstraction
-	kavaClaimer.Run(ctx)
-	bnbClaimer.Run(ctx) // XXX G5 duplication
+	ctx := context.Background()
+	kavaClaimer.Start(ctx)
+	bnbClaimer.Start(ctx)
 
 	select {}
 }

--- a/deputy-claimer/test/integration/basic_test.go
+++ b/deputy-claimer/test/integration/basic_test.go
@@ -75,7 +75,7 @@ func TestClaimBnb(t *testing.T) {
 		addresses.BnbNodeURL,
 		getDeputyAddresses(addrs),
 		addrs.BnbUserMnemonics()[:2],
-	).Run(ctx)
+	).Start(ctx)
 	defer shutdownClaimer()
 	time.Sleep(8 * time.Second)
 
@@ -130,7 +130,7 @@ func TestClaimKava(t *testing.T) {
 		addresses.BnbNodeURL,
 		getDeputyAddresses(addrs),
 		addrs.KavaUserMnemonics()[:2],
-	).Run(ctx)
+	).Start(ctx)
 	defer shutdownClaimer()
 	time.Sleep(8 * time.Second)
 

--- a/deputy-claimer/test/integration/concurrency_test.go
+++ b/deputy-claimer/test/integration/concurrency_test.go
@@ -69,7 +69,7 @@ func TestMultipleClaimBnb(t *testing.T) {
 		addresses.BnbNodeURL,
 		getDeputyAddresses(addrs),
 		addrs.BnbUserMnemonics()[:2],
-	).Run(ctx)
+	).Start(ctx)
 	defer shutdownClaimer()
 
 	time.Sleep(30 * time.Second) // TODO
@@ -133,7 +133,7 @@ func TestMultipleClaimKava(t *testing.T) {
 		addresses.BnbNodeURL,
 		getDeputyAddresses(addrs),
 		addrs.KavaUserMnemonics()[:2],
-	).Run(ctx)
+	).Start(ctx)
 	defer shutdownClaimer()
 
 	time.Sleep(30 * time.Second) // TODO


### PR DESCRIPTION
When claiming kava swaps, the claimer often timed out and sent error messages. The txs still go through as they just take a while. If they didn't go through the claimer tries again next iteration.

This PR also removes the code review comments.