### PR TITLE
Add Dockerfile for `alerts` service

### DIFF
--- a/alerts/Dockerfile
+++ b/alerts/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.16.7-buster as build-env
+FROM golang:1.17-bullseye as build-env
 
 ADD . /src
 RUN cd /src && go build -o /alerts
 
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update \
       && apt-get install -y ca-certificates \

--- a/alerts/Dockerfile
+++ b/alerts/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.16.7-buster as build-env
+
+ADD . /src
+RUN cd /src && go build -o /alerts
+
+FROM debian:buster
+
+RUN apt-get update \
+      && apt-get install -y ca-certificates \
+      && rm -rf /var/lib/apt/lists/* \
+      && update-ca-certificates
+
+COPY --from=build-env /alerts /
+
+CMD ["/alerts"]

--- a/alerts/Makefile
+++ b/alerts/Makefile
@@ -1,2 +1,28 @@
+AWS:=aws
+AWS_REGION:=us-east-1
+AWS_ACCOUNT_ID=$(shell aws sts get-caller-identity --query 'Account' --output text)
+DOCKER:=docker
+IMAGE_NAME:=alerts
+COMMIT_ID_SHORT:=$(shell git rev-parse --short HEAD)
+DOCKER_REPOSITORY_URL:=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(IMAGE_NAME)
+
 install:
 	go install
+
+.PHONY: docker-login
+docker-login:
+	$(AWS) ecr get-login-password --region $(AWS_REGION) | \
+	docker login --username AWS --password-stdin \
+	$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+
+.PHONY: docker-build
+docker-build:
+	$(DOCKER) build -t $(IMAGE_NAME):$(COMMIT_ID_SHORT) .
+
+.PHONY: docker-tag
+docker-tag:
+	$(DOCKER) tag $(IMAGE_NAME):$(COMMIT_ID_SHORT) $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)
+
+.PHONY: docker-push
+docker-push:
+	$(DOCKER) push $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)

--- a/alerts/README.md
+++ b/alerts/README.md
@@ -10,8 +10,8 @@ Bot for sending alerts to Slack for various events on the Kava blockchain.
 
 ## DynamoDB Setup
 
-1. Create a new DynamoDB table with the primary parition key set to `Service` and
-   sort key to `RpcEndpoint`.
+1. Create a new DynamoDB table with the primary partition key set to
+   `ServiceName` and sort key to `RpcEndpoint`.
 
 The latest alert time is persisted in DynamoDB which is used by
 `ALERT_FREQUENCY` below. This will only alert at most once in the given alert

--- a/alerts/cmd/auctions.go
+++ b/alerts/cmd/auctions.go
@@ -32,12 +32,14 @@ var runAuctionsCmd = &cobra.Command{
 		// Create base logger
 		logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 
-		// Load config. If config is not valid, exit with fatal error
+		// Load config. If config is not valid, exit with error
 		config, err := config.LoadAuctionsConfig(&config.EnvLoader{})
 		if err != nil {
 			return err
 		}
 
+		// Create a new alert persister backed with DynamoDB. If AWS config is
+		// invalid, exits with error
 		db, err := persistence.NewDynamoDbPersister(config.DynamoDbTableName, _auctionsServiceName, config.KavaRpcUrl)
 		if err != nil {
 			return err

--- a/alerts/cmd/auctions.go
+++ b/alerts/cmd/auctions.go
@@ -33,7 +33,7 @@ var runAuctionsCmd = &cobra.Command{
 		logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 
 		// Load config. If config is not valid, exit with error
-		config, err := config.LoadAuctionsConfig(&config.EnvLoader{})
+		config, err := config.LoadAuctionsConfig(&config.EnvLoader{}, logger)
 		if err != nil {
 			return err
 		}

--- a/alerts/cmd/usdx.go
+++ b/alerts/cmd/usdx.go
@@ -34,7 +34,7 @@ var runUsdxCmd = &cobra.Command{
 		logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 
 		// Load config. If config is not valid, exit with fatal error
-		config, err := config.LoadUsdxConfig(&config.EnvLoader{})
+		config, err := config.LoadUsdxConfig(&config.EnvLoader{}, logger)
 		if err != nil {
 			return err
 		}

--- a/alerts/config/auctions.go
+++ b/alerts/config/auctions.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 type AuctionsConfig struct {
@@ -12,8 +13,8 @@ type AuctionsConfig struct {
 }
 
 // LoadAuctionsConfig loads key values from a ConfigLoader and returns a new AuctionsConfig
-func LoadAuctionsConfig(loader ConfigLoader) (AuctionsConfig, error) {
-	baseConfig, err := LoadBaseConfig(loader)
+func LoadAuctionsConfig(loader ConfigLoader, logger log.Logger) (AuctionsConfig, error) {
+	baseConfig, err := LoadBaseConfig(loader, logger)
 	if err != nil {
 		return AuctionsConfig{}, err
 	}

--- a/alerts/config/base.go
+++ b/alerts/config/base.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 // Config provides application configuration
@@ -18,10 +19,12 @@ type BaseConfig struct {
 
 // LoadBaseConfig loads key values from a ConfigLoader and returns a new
 // BaseConfig used for multiple different commands
-func LoadBaseConfig(loader ConfigLoader) (BaseConfig, error) {
+func LoadBaseConfig(loader ConfigLoader, logger log.Logger) (BaseConfig, error) {
 	// Ignore error from godotenv, continue if there isn't an .env file and
 	// check if required env vars already exist
-	godotenv.Load()
+	if err := godotenv.Load(); err != nil {
+		logger.Info(".env not found, attempting to proceed with available env variables")
+	}
 
 	rpcURL := loader.Get(kavaRpcUrlEnvKey)
 	if rpcURL == "" {

--- a/alerts/config/base.go
+++ b/alerts/config/base.go
@@ -26,11 +26,6 @@ func LoadBaseConfig(loader ConfigLoader, logger log.Logger) (BaseConfig, error) 
 		logger.Info(".env not found, attempting to proceed with available env variables")
 	}
 
-	rpcURL := loader.Get(kavaRpcUrlEnvKey)
-	if rpcURL == "" {
-		return BaseConfig{}, fmt.Errorf("%s not set", kavaRpcUrlEnvKey)
-	}
-
 	dynamoDbTableName := loader.Get(dynamoDbTableNameEnvKey)
 	if dynamoDbTableName == "" {
 		return BaseConfig{}, fmt.Errorf("%s not set", dynamoDbTableNameEnvKey)

--- a/alerts/config/base.go
+++ b/alerts/config/base.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -18,15 +19,29 @@ type BaseConfig struct {
 // LoadBaseConfig loads key values from a ConfigLoader and returns a new
 // BaseConfig used for multiple different commands
 func LoadBaseConfig(loader ConfigLoader) (BaseConfig, error) {
-	err := godotenv.Load()
-	if err != nil {
-		return BaseConfig{}, err
+	// Ignore error from godotenv, continue if there isn't an .env file and
+	// check if required env vars already exist
+	godotenv.Load()
+
+	rpcURL := loader.Get(kavaRpcUrlEnvKey)
+	if rpcURL == "" {
+		return BaseConfig{}, fmt.Errorf("%s not set", kavaRpcUrlEnvKey)
 	}
 
 	dynamoDbTableName := loader.Get(dynamoDbTableNameEnvKey)
+	if dynamoDbTableName == "" {
+		return BaseConfig{}, fmt.Errorf("%s not set", dynamoDbTableNameEnvKey)
+	}
 
 	slackToken := loader.Get(slackTokenEnvKey)
+	if slackToken == "" {
+		return BaseConfig{}, fmt.Errorf("%s not set", slackToken)
+	}
+
 	slackChannelId := loader.Get(slackChannelIdEnvKey)
+	if slackChannelId == "" {
+		return BaseConfig{}, fmt.Errorf("%s not set", slackChannelId)
+	}
 
 	updateInterval, err := time.ParseDuration(loader.Get(intervalEnvKey))
 	if err != nil {

--- a/alerts/config/usdx.go
+++ b/alerts/config/usdx.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
 type UsdxConfig struct {
@@ -13,8 +14,8 @@ type UsdxConfig struct {
 }
 
 // LoadUsdxConfig loads key values from a ConfigLoader and returns a new UsdxConfig
-func LoadUsdxConfig(loader ConfigLoader) (UsdxConfig, error) {
-	baseConfig, err := LoadBaseConfig(loader)
+func LoadUsdxConfig(loader ConfigLoader, logger log.Logger) (UsdxConfig, error) {
+	baseConfig, err := LoadBaseConfig(loader, logger)
 	if err != nil {
 		return UsdxConfig{}, err
 	}


### PR DESCRIPTION
* Adds a `Dockerfile`
* Adds docker tasks in the `Makefile`
* Makes changes to the `alerts` service such that it does not exit if an `.env` file is not found and attempts to check for existing envvars.