### PR TITLE
Fix claimer docker builds

### DIFF
--- a/claimer/Dockerfile
+++ b/claimer/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.17.5-bullseye as build-env
+
+ADD . /src
+# Mount go build and mod caches as container caches, persisted between builder invocations, for faster repeated builds.
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod cd /src/claimer && go build -o /main
+
+FROM debian:bullseye
+
+RUN apt-get update \
+      && apt-get install -y ca-certificates \
+      && rm -rf /var/lib/apt/lists/* \
+      && update-ca-certificates
+
+COPY --from=build-env /main /
+
+CMD ["/main"]

--- a/claimer/Makefile
+++ b/claimer/Makefile
@@ -1,7 +1,26 @@
+DOCKER:=docker
+IMAGE_NAME:=claimer
+COMMIT_ID_SHORT:=$(shell git rev-parse --short HEAD)
+DOCKER_REPOSITORY_URL:=kava/$(IMAGE_NAME)
+
+.PHONY: install
 install:
 	go install -mod=readonly ./
 
+.PHONY: test-integration
 test-integration:
 	@# run go vet first to avoid waiting for containers to spin up before finding there's a typo
 	go vet -tags integration ./...
 	cd test/integration && ./run-tests.sh
+
+.PHONY: docker-build
+docker-build:
+	cd .. ; $(DOCKER) build -t $(IMAGE_NAME):$(COMMIT_ID_SHORT) -f claimer/Dockerfile .
+
+.PHONY: docker-tag
+docker-tag:
+	$(DOCKER) tag $(IMAGE_NAME):$(COMMIT_ID_SHORT) $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)
+
+.PHONY: docker-push
+docker-push:
+	$(DOCKER) push $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)

--- a/deputy-claimer/Dockerfile
+++ b/deputy-claimer/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.15.6-buster as build-env
 
 ADD . /src
-RUN cd /src && go build -o /main
+RUN cd /src/deputy-claimer && go build -o /main
 
 FROM debian:buster
 

--- a/deputy-claimer/Makefile
+++ b/deputy-claimer/Makefile
@@ -30,7 +30,7 @@ docker-login:
 
 .PHONY: docker-build
 docker-build:
-	$(DOCKER) build -t $(IMAGE_NAME):$(COMMIT_ID_SHORT) .
+	cd ..; $(DOCKER) build -t $(IMAGE_NAME):$(COMMIT_ID_SHORT) -f deputy-claimer/Dockerfile .
 
 .PHONY: docker-tag
 docker-tag:


### PR DESCRIPTION
The deputy-claimer docker build broke when it changed to a shared go.mod.

This also adds a Dockerfile for the claimer to be used in kvtool, and eventually aws.