### PR TITLE
Add CORS Support & Update Docker to build on M1

### DIFF
--- a/claimer/Dockerfile
+++ b/claimer/Dockerfile
@@ -1,8 +1,9 @@
 FROM golang:1.17.5-bullseye as build-env
 
+ARG TARGETOS TARGETARCH
 ADD . /src
 # Mount go build and mod caches as container caches, persisted between builder invocations, for faster repeated builds.
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod cd /src && go build -o /main
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod cd /src && GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /main
 
 FROM debian:bullseye
 

--- a/claimer/Dockerfile
+++ b/claimer/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.17.5-bullseye as build-env
+FROM --platform=$BUILDPLATFORM golang:1.17.5-bullseye as build-env
 
 ARG TARGETOS TARGETARCH
 ADD . /src
-# Mount go build and mod caches as container caches, persisted between builder invocations, for faster repeated builds.
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod cd /src && GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /main
+RUN cd /src/claimer && GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /main
 
 FROM debian:bullseye
 

--- a/claimer/Makefile
+++ b/claimer/Makefile
@@ -22,18 +22,6 @@ docker-login:
 	docker login --username AWS --password-stdin \
 	$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 
-.PHONY: docker-build
-docker-build:
-	$(DOCKER) build -t $(IMAGE_NAME):$(COMMIT_ID_SHORT) .
-
-.PHONY: docker-tag
-docker-tag:
-	$(DOCKER) tag $(IMAGE_NAME):$(COMMIT_ID_SHORT) $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)
-
-.PHONY: docker-push
-docker-push:
-	$(DOCKER) push $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)
-
 .PHONY: docker-build-and-push
 docker-build-and-push:
 	cd ..; $(DOCKER) buildx build --platform linux/amd64  -t $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT) -f claimer/Dockerfile --push .

--- a/claimer/Makefile
+++ b/claimer/Makefile
@@ -33,3 +33,7 @@ docker-tag:
 .PHONY: docker-push
 docker-push:
 	$(DOCKER) push $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT)
+
+.PHONY: docker-build-and-push
+docker-build-and-push:
+	cd ..; $(DOCKER) buildx build --platform linux/amd64  -t $(DOCKER_REPOSITORY_URL):$(COMMIT_ID_SHORT) -f claimer/Dockerfile --push .

--- a/claimer/go.mod
+++ b/claimer/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/cosmos/cosmos-sdk v0.44.5
 	github.com/google/uuid v1.1.2
+	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/kava-labs/binance-chain-go-sdk v1.2.5-kava
 	github.com/kava-labs/go-sdk v0.5.1-0.20211220154055-4aeeffe85ecd
@@ -56,7 +57,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/btree v1.0.0 // indirect
-	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect

--- a/claimer/server/server.go
+++ b/claimer/server/server.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 )
@@ -57,7 +58,7 @@ func (s *Server) Start() error {
 	r.HandleFunc("/claim", s.claim).Methods(http.MethodPost)
 	r.HandleFunc("/status", s.status)
 	r.HandleFunc("/", s.notFound)
-	s.httpServer = &http.Server{Addr: ":8080", Handler: r}
+	s.httpServer = &http.Server{Addr: ":8080", Handler: handlers.CORS(handlers.AllowedOrigins([]string{"*"}))(r)}
 	return s.httpServer.ListenAndServe()
 }
 


### PR DESCRIPTION
- We used to enabled CORS in nginx, now added to directly to the go server
- Update docker build to use buildx and force amd64