### PR TITLE
Increase claimer kava tx retry timeout

### DIFF
--- a/claimer/claimer/workers.go
+++ b/claimer/claimer/workers.go
@@ -28,7 +28,7 @@ const (
 	ClaimTxDefaultGas = 200_000
 
 	// TxConfirmationTimeout is the longest time to wait for a tx confirmation before giving up
-	TxConfirmationTimeout      = 3 * 60 * time.Second
+	TxConfirmationTimeout      = 60 * 60 * time.Second
 	TxConfirmationPollInterval = 2 * time.Second
 )
 


### PR DESCRIPTION
Extends the timeout the web app bep3 claimer uses before giving up on claiming a bep3 deposit. Before it was 3 minutes, extending to the full hour window allowed by the bep3 swap itself. It uses exponential backoff so shouldn't increase load too much.