### PR TITLE
auction-bot: get chain id from env

### DIFF
--- a/auction-bot/README.md
+++ b/auction-bot/README.md
@@ -7,6 +7,8 @@ Automated bot for bidding on collateral and debt auctions on the Kava platform. 
 Create a `.env` file:
 
 ```
+# Chain id is the network id for the chain
+KAVA_CHAIN_ID=kava_2222-10
 # GRPC endpoint, scheme must be included
 KAVA_GRPC_URL="https://grpc.testnet.kava.io:443"
 # Mnemonic
@@ -30,4 +32,4 @@ PRICE_OVERRIDES="{\"usdc\": \"1.00\",\"example\":\"1.234\"}"
 go run .
 ```
 
-Bot will bid attempt to bid on all auctions where the profit margin is greater than what is specified in `BID_MARGIN`. Note, bot does not currently track account balances, so it will attempt to create bids even for auctions for which it doesn't have sufficient funds.  
+Bot will bid attempt to bid on all auctions where the profit margin is greater than what is specified in `BID_MARGIN`. Note, bot does not currently track account balances, so it will attempt to create bids even for auctions for which it doesn't have sufficient funds.

--- a/auction-bot/config.go
+++ b/auction-bot/config.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	kavaChainIdEnvKey       = "KAVA_CHAIN_ID"
 	kavaGrpcUrlEnvKey       = "KAVA_GRPC_URL"
 	mnemonicEnvKey          = "KEEPER_MNEMONIC"
 	profitMarginKey         = "BID_MARGIN"
@@ -28,6 +29,7 @@ type ConfigLoader interface {
 
 // Config provides application configuration
 type Config struct {
+	KavaChainId          string
 	KavaGrpcUrl          string
 	KavaBidInterval      time.Duration
 	KavaKeeperMnemonic   string
@@ -42,6 +44,10 @@ func LoadConfig(loader ConfigLoader) (Config, error) {
 	err := godotenv.Load()
 	if err != nil {
 		fmt.Printf(".env not found, attempting to proceed with available env variables\n")
+	}
+	chainId := loader.Get(kavaChainIdEnvKey)
+	if chainId == "" {
+		return Config{}, fmt.Errorf("%s not set", kavaChainIdEnvKey)
 	}
 	grpcURL := loader.Get(kavaGrpcUrlEnvKey)
 	if grpcURL == "" {
@@ -78,6 +84,7 @@ func LoadConfig(loader ConfigLoader) (Config, error) {
 	}
 
 	return Config{
+		KavaChainId:          chainId,
 		KavaGrpcUrl:          grpcURL,
 		KavaBidInterval:      keeperBidInterval,
 		KavaKeeperMnemonic:   keeperMnemonic,

--- a/auction-bot/main.go
+++ b/auction-bot/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kava-labs/kava/app"
 	"github.com/rs/zerolog"
 
-	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -43,6 +42,7 @@ func main() {
 
 	logger.
 		Info().
+		Str("chainId", config.KavaChainId).
 		Str("grpcUrl", config.KavaGrpcUrl).
 		Dur("bidInterval", config.KavaBidInterval).
 		Str("profitMargin", config.ProfitMargin.String()).
@@ -78,13 +78,8 @@ func main() {
 		Str("signing address", sdk.AccAddress(privKey.PubKey().Address()).String()).
 		Send()
 
-	nodeInfoResponse, err := grpcClient.Tm.GetNodeInfo(context.Background(), &tmservice.GetNodeInfoRequest{})
-	if err != nil {
-		logger.Fatal().Err(err).Msg("failed to fetch chain id")
-	}
-
 	signer := signing.NewSigner(
-		nodeInfoResponse.DefaultNodeInfo.Network,
+		config.KavaChainId,
 		encodingConfig,
 		grpcClient.Auth,
 		grpcClient.Tx,


### PR DESCRIPTION
auction bot now pulls the chain id from an environment variable rather than query the chain for it.