### PR TITLE
fix(auctions): min bid wasn't calculated correctly for tiny auctions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,9 +2,6 @@ run:
   timeout: 20m # set maximum time allowed for the linter to run. If the linting process exceeds this duration, it will be terminated
   modules-download-mode: readonly # Ensures that modules are not modified during the linting process
   allow-parallel-runners: true # enables parallel execution of linters to speed up linting process
-  skip-dirs:
-    - vendor
-    - hard-keeper-bot # TODO(boodyvo): a lot of errors for old code, need to fix during the hard-keeper-bot update
 
 linters:
   disable-all: true
@@ -15,6 +12,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - decorder
     - dogsled
     #    - dupl
@@ -25,7 +23,6 @@ linters:
     - errname
     - errorlint
     #    - exhaustive
-    - exportloopref
     - funlen
     - gci
     - ginkgolinter
@@ -85,6 +82,9 @@ linters:
     - wrapcheck
 
 issues:
+  exclude-dirs:
+    - vendor
+    - hard-keeper-bot # TODO(boodyvo): a lot of errors for old code, need to fix during the hard-keeper-bot update
   exclude-rules:
     # Disable funlen for "func Test..." or func (suite *Suite) Test..." type functions
     # These functions tend to be descriptive and exceed length limits.
@@ -96,11 +96,6 @@ linters-settings:
   errcheck:
     check-blank: true # check for assignments to the blank identifier '_' when errors are returned
     check-type-assertions: false # check type assertion
-  errorlint:
-    check-generated: false # disabled linting of generated files
-    default-signifies-exhaustive: false # exhaustive handling of error types
-  exhaustive:
-    default-signifies-exhaustive: false # exhaustive handling of error types
   gci:
     sections: # defines the order of import sections
       - standard
@@ -120,11 +115,6 @@ linters-settings:
     line-length: 120
   misspell:
     locale: US
-    ignore-words: expect
-  nolintlint:
-    allow-leading-space: false
-    require-explanation: true
-    require-specific: true
   prealloc:
     simple: true # enables simple preallocation checks
     range-loops: true # enabled preallocation checks in range loops

--- a/auction-bot/Dockerfile
+++ b/auction-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.9-bookworm as build-env
+FROM golang:1.23.6-bookworm AS build-env
 
 ADD . /src
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/auction-bot/calc.go
+++ b/auction-bot/calc.go
@@ -54,6 +54,7 @@ func GetBids(
 					auction,
 					keeper,
 					data.Assets,
+					data.BidIncrement,
 					margin,
 				)
 				if !shouldBid {
@@ -110,6 +111,7 @@ func handleForwardCollateralAuction(
 	auction auctiontypes.Auction,
 	keeper sdk.AccAddress,
 	assetInfo map[string]AssetInfo,
+	increment,
 	margin sdk.Dec,
 ) (AuctionInfo, bool) {
 	collateralAuction := auction.(*auctiontypes.CollateralAuction)
@@ -130,6 +132,7 @@ func handleForwardCollateralAuction(
 		assetInfoLot,
 		assetInfoBid,
 		margin,
+		increment,
 		collateralAuction.GetID(),
 	)
 
@@ -268,7 +271,7 @@ func calculateUSDValue(coin sdk.Coin, assetInfo AssetInfo) sdk.Dec {
 func calculateProposedBid(
 	currentBid, lot, maxbid sdk.Coin,
 	assetInfoLot, assetInfoBid AssetInfo,
-	margin sdk.Dec,
+	margin, increment sdk.Dec,
 	id uint64,
 ) (sdk.Coin, bool) {
 	bidsToTry := []sdk.Dec{d("1.0"), d("0.95"), d("0.9"), d("0.8"), d("0.7"), d("0.6"), d("0.5"), d("0.4"), d("0.3"), d("0.2"), d("0.1")}
@@ -276,7 +279,7 @@ func calculateProposedBid(
 	if lotUSDValue.IsZero() {
 		return sdk.Coin{}, false
 	}
-	minBid := currentBid.Amount.ToLegacyDec().Mul(d("1.0105")).RoundInt()
+	minBid := minNewBid(currentBid.Amount, increment)
 	if minBid.GT(maxbid.Amount) {
 		minBid = maxbid.Amount
 	}
@@ -305,6 +308,17 @@ func calculateProposedBid(
 	return sdk.Coin{}, false
 }
 
+// minNewBid calculates the smallest new bid that can be placed.
+// It returns the current bid + 1%. Unless the increment is <1 in which case its the current bid + 1.
+func minNewBid(currentBid sdk.Int, increment sdk.Dec) sdk.Int {
+
+	return currentBid.Add( // new bids must be some % greater than old bid, and at least 1 larger to avoid replacing an old bid at no cost
+		sdk.MaxInt(
+			sdk.NewInt(1),
+			sdk.NewDecFromInt(currentBid).Mul(increment).RoundInt(),
+		),
+	)
+}
 
 // calculateProposedLot tries to find a lot amount to bid in a reverse auction.
 // Rather than finding the smallest amount the lot could be reduced by, it finds the largest decrement that still makes a profit.

--- a/auction-bot/calc_test.go
+++ b/auction-bot/calc_test.go
@@ -62,6 +62,38 @@ func TestGetBids(t *testing.T) {
 				Amount: c("usdx", 176_000e6),
 			}},
 		},
+		{
+			name: "min increment forward auction",
+			auctionData: AuctionData{
+				Auctions: []auctiontypes.Auction{
+					&auctiontypes.CollateralAuction{
+						BaseAuction: auctiontypes.BaseAuction{
+							ID:  0,
+							Lot: c("xrp", 25),
+							Bid: c("ukava", 1),
+						},
+						MaxBid:            c("ukava", 4),
+						CorrespondingDebt: c("debt", 0),
+					},
+				},
+				Assets: map[string]AssetInfo{
+					"xrp": {
+						Price:            d("2.00"),
+						ConversionFactor: sdk.NewInt(1e8),
+					},
+					"ukava": {
+						Price:            d("0.44"),
+						ConversionFactor: sdk.NewInt(1e6),
+					},
+				},
+				BidIncrement: d("0.01"),
+			},
+			margin: d("0.05"),
+			expectedBids: AuctionInfos{{
+				ID:     0,
+				Amount: c("ukava", 2),
+			}},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/auction-bot/go.mod
+++ b/auction-bot/go.mod
@@ -1,6 +1,6 @@
 module github.com/kava-labs/go-tools/auction-bot
 
-go 1.21.9
+go 1.23.6
 
 require (
 	github.com/alexliesenfeld/health v0.8.0


### PR DESCRIPTION
For tiny (forward) auctions, the bot could bid the same as the current bid. This is never allowed by the chain as all bids must at least be 1 unit larger than previous.

This PR replicates the bug in a test and copies in the min bid calculation from the auction module.